### PR TITLE
Android: throw SlothException when decrypting with cached secret

### DIFF
--- a/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/SlothLibTest.kt
+++ b/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/SlothLibTest.kt
@@ -134,6 +134,12 @@ class SlothLibTest {
             hiddenSloth1.decryptFromStorage("wrong passphrase")
         }
 
+        // does not decrypt under a different passphrase with pre-computed secrets
+        assertThatExceptionOfType(SlothDecryptionFailed::class.java).isThrownBy {
+            val wrongCachedSecrets = hiddenSloth1.computeCachedSecrets("wrong passphrase")
+            hiddenSloth1.decryptFromStorageWithCachedSecrets(wrongCachedSecrets)
+        }
+
         // decrypts from another instance
         val hiddenSloth3 = instance.getHiddenSlothInstance(
             identifier = "hidden_sloth_test",

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/HiddenSloth.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/HiddenSloth.kt
@@ -174,12 +174,19 @@ class HiddenSloth internal constructor(
         check(isInitialized)
         val namespacedStorage = storage.getOrCreateNamespace(identifier)
 
-        return impl.decrypt(
-            storage = namespacedStorage,
-            pw = null,
-            cachedSecrets = cachedSecrets,
-            decryptionOffsetAndLength = decryptionOffsetAndLength
-        )
+        try {
+            return impl.decrypt(
+                storage = namespacedStorage,
+                pw = null,
+                cachedSecrets = cachedSecrets,
+                decryptionOffsetAndLength = decryptionOffsetAndLength
+            )
+        } catch (e: AEADBadTagException) {
+            throw SlothDecryptionFailed(
+                message = "Decryption failed for key $identifier. This might mean there was never any user data stored.",
+                cause = e
+            )
+        }
     }
 
     private fun identifierToHandle(identifier: String) =


### PR DESCRIPTION
**Summary**

Closes #11 

**Test plan**

New tests. Tested before and after fix using device farm (Samsung S22).