### PR TITLE
Android: prefer CharArray over String

### DIFF
--- a/android/app/src/main/java/com/lambdapioneer/sloth/app/models/HiddenSlothViewModel.kt
+++ b/android/app/src/main/java/com/lambdapioneer/sloth/app/models/HiddenSlothViewModel.kt
@@ -46,15 +46,16 @@ class HiddenSlothViewModel(
     fun store(password: String, content: String, useCachedSecrets: Boolean) {
         runLongTaskInBackground {
             val data = content.encodeToByteArray()
+            val passwordCharArray = password.toCharArray()
             if (useCachedSecrets) {
-                val cachedSecrets = hiddenSloth.computeCachedSecrets(pw = password)
+                val cachedSecrets = hiddenSloth.computeCachedSecrets(pw = passwordCharArray)
                 hiddenSloth.encryptToStorageWithCachedSecrets(
                     cachedSecrets = cachedSecrets,
                     data = data
                 )
             } else {
                 hiddenSloth.encryptToStorage(
-                    pw = password,
+                    pw = passwordCharArray,
                     data = data,
                 )
             }
@@ -63,11 +64,12 @@ class HiddenSlothViewModel(
 
     fun load(password: String, useCachedSecrets: Boolean) {
         runLongTaskInBackground {
+            val passwordCharArray = password.toCharArray()
             val contentBytes = if (useCachedSecrets) {
-                val cachedSecrets = hiddenSloth.computeCachedSecrets(pw = password)
+                val cachedSecrets = hiddenSloth.computeCachedSecrets(pw = passwordCharArray)
                 hiddenSloth.decryptFromStorageWithCachedSecrets(cachedSecrets)
             } else {
-                hiddenSloth.decryptFromStorage(pw = password)
+                hiddenSloth.decryptFromStorage(pw = passwordCharArray)
             }
             this.output.value = contentBytes.decodeToString()
         }

--- a/android/app/src/main/java/com/lambdapioneer/sloth/app/models/LongSlothViewModel.kt
+++ b/android/app/src/main/java/com/lambdapioneer/sloth/app/models/LongSlothViewModel.kt
@@ -32,13 +32,13 @@ class LongSlothViewModel(
 
     fun generateKey(password: String) {
         runLongTaskInBackground {
-            key.value = longSloth.createNewKey(pw = password)
+            key.value = longSloth.createNewKey(pw = password.toCharArray())
         }
     }
 
     fun deriveKey(password: String) {
         runLongTaskInBackground {
-            key.value = longSloth.deriveForExistingKey(pw = password)
+            key.value = longSloth.deriveForExistingKey(pw = password.toCharArray())
         }
     }
 

--- a/android/sloth-pwhash-libsodium/src/androidTest/java/com/lambdapioneer/sloth/pwhash_libsodium/LibSodiumArgon2PwHashTest.kt
+++ b/android/sloth-pwhash-libsodium/src/androidTest/java/com/lambdapioneer/sloth/pwhash_libsodium/LibSodiumArgon2PwHashTest.kt
@@ -6,7 +6,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 
-@Suppress("UsePropertyAccessSyntax")
 @RunWith(AndroidJUnit4::class)
 class LibSodiumArgon2PwHashTest {
 
@@ -15,8 +14,8 @@ class LibSodiumArgon2PwHashTest {
 
     @Test
     fun testHash_whenSameInput_thenSameOutput() {
-        val h1 = instance.deriveHash(salt, "test", 32)
-        val h2 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
+        val h2 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         assertThat(h1).isEqualTo(h2)
     }
@@ -24,7 +23,7 @@ class LibSodiumArgon2PwHashTest {
     @Test
     fun testHash_whenModerateParameters_thenSucceeds() {
         val instance = LibSodiumArgon2PwHash(LibSodiumArgon2PwHashParams.MODERATE)
-        val h1 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         assertThat(h1).isNotEmpty()
     }
@@ -32,7 +31,7 @@ class LibSodiumArgon2PwHashTest {
     @Test
     fun testHash_whenInteractiveParameters_thenSucceeds() {
         val instance = LibSodiumArgon2PwHash(LibSodiumArgon2PwHashParams.INTERACTIVE)
-        val h1 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         assertThat(h1).isNotEmpty()
     }
@@ -40,7 +39,7 @@ class LibSodiumArgon2PwHashTest {
     @Test
     fun testHash_whenOwaspParameters_thenSucceeds() {
         val instance = LibSodiumArgon2PwHash(LibSodiumArgon2PwHashParams.OWASP)
-        val h1 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         assertThat(h1).isNotEmpty()
     }
@@ -48,26 +47,59 @@ class LibSodiumArgon2PwHashTest {
     @Test
     fun testHash_whenLongKeyLength_thenSucceeds() {
         val len = 10 * 1024 * 1024 // 10 MiB
-        val h = instance.deriveHash(salt, "test", len)
+        val h = instance.deriveHash(salt, "test".toCharArray(), len)
 
         assertThat(h).hasSize(len)
     }
 
     @Test
     fun testHash_whenDifferentSalt_thenDifferentOutput() {
-        val h1 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         val differentSalt = instance.createSalt()
-        val h2 = instance.deriveHash(differentSalt, "test", 32)
+        val h2 = instance.deriveHash(differentSalt, "test".toCharArray(), 32)
 
         assertThat(h1).isNotEqualTo(h2)
     }
 
     @Test
     fun testHash_whenDifferentPassword_thenDifferentOutput() {
-        val h1 = instance.deriveHash(salt, "test", 32)
-        val h2 = instance.deriveHash(salt, "different", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
+        val h2 = instance.deriveHash(salt, "different".toCharArray(), 32)
 
         assertThat(h1).isNotEqualTo(h2)
     }
+
+    /**
+     * This method ensures that the returned hash remains backwards-compatible between different
+     * releases. Do not update the `expected` output.
+     */
+    @Test
+    fun testHash_whenGivenFixedInput_thenMatchesExpected() {
+        internalTestVectorAssertion(
+            params = LibSodiumArgon2PwHashParams.INTERACTIVE,
+            expected = "4ff03446cb47263568f801f9e36412b4c182b4a039ac84fe3bb03c3528961491"
+        )
+        internalTestVectorAssertion(
+            params = LibSodiumArgon2PwHashParams.MODERATE,
+            expected = "43de47cf7103d0fa6aa9dd1425089fcd4c793fc6c75496089396814517f97ce8"
+        )
+        internalTestVectorAssertion(
+            params = LibSodiumArgon2PwHashParams.OWASP,
+            expected = "9df7459c90d889cf7e255e517c4299392ce860eed2d20f1a7cecda42bb2998bc"
+        )
+    }
+
+    private fun internalTestVectorAssertion(params: LibSodiumArgon2PwHashParams, expected: String) {
+        val salt = "00112233445566778899AABBCCDDEEFF".decodeAsHex()
+        val password = "passphrase äüö"
+
+        val instance = LibSodiumArgon2PwHash(params)
+        val actual = instance.deriveHash(salt, password.toCharArray(), 32)
+        assertThat(actual).isEqualTo(expected.decodeAsHex())
+    }
+}
+
+private fun String.decodeAsHex() = ByteArray(this.length / 2) {
+    this.substring(2 * it, 2 * it + 2).toInt(radix = 16).toByte()
 }

--- a/android/sloth-pwhash-libsodium/src/main/java/com/lambdapioneer/sloth/pwhash_libsodium/LibSodiumArgon2PwHash.kt
+++ b/android/sloth-pwhash-libsodium/src/main/java/com/lambdapioneer/sloth/pwhash_libsodium/LibSodiumArgon2PwHash.kt
@@ -3,6 +3,9 @@ package com.lambdapioneer.sloth.pwhash_libsodium
 import com.goterl.lazysodium.SodiumAndroid
 import com.lambdapioneer.sloth.crypto.PwHash
 import com.lambdapioneer.sloth.utils.secureRandomBytes
+import java.nio.CharBuffer
+import java.util.Arrays
+import com.goterl.lazysodium.interfaces.PwHash as LibSodiumPwHash
 
 
 class LibSodiumArgon2PwHash(
@@ -18,25 +21,41 @@ class LibSodiumArgon2PwHash(
 
     override fun deriveHash(
         salt: ByteArray,
-        password: String,
+        password: CharArray,
         outputLengthInBytes: Int,
     ): ByteArray {
         require(salt.size == SALT_LEN)
         require(outputLengthInBytes > 0)
         require(password.isNotEmpty())
 
-        val passwordBytes = password.encodeToByteArray()
-        val result = ByteArray(outputLengthInBytes)
+        // Wrapping creates no internal copy
+        val passwordCharBuffer = CharBuffer.wrap(password)
 
-        val libSodiumResult = libSodium.crypto_pwhash(
-            result, result.size.toLong(),
-            passwordBytes, passwordBytes.size.toLong(),
-            salt,
-            params.opsLimit,
-            params.memLimit,
-            com.goterl.lazysodium.interfaces.PwHash.Alg.PWHASH_ALG_ARGON2ID13.value,
-        )
-        check(libSodiumResult == 0)
+        // The encode operation "should" be compatible with `String.encodeToByteArray()` and
+        // returns an array-backed `ByteBuffer`. Hence, we avoid the intermediate step via
+        // an immutable String that lingers in memory
+        val passwordBytesBuffer = Charsets.UTF_8.encode(passwordCharBuffer)
+        check(passwordBytesBuffer.hasArray())
+
+        val passwordBytesArray = passwordBytesBuffer.array()
+        val passwordBytesArrayLength = passwordBytesBuffer.limit()
+
+        val result = ByteArray(outputLengthInBytes)
+        try {
+            val libSodiumResult = libSodium.crypto_pwhash(
+                /* outputHash = */ result,
+                /* outputHashLen = */ result.size.toLong(),
+                /* password = */ passwordBytesArray,
+                /* passwordLen = */ passwordBytesArrayLength.toLong(),
+                /* salt = */ salt,
+                /* opsLimit = */ params.opsLimit,
+                /* memLimit = */ params.memLimit,
+                /* alg = */ LibSodiumPwHash.Alg.PWHASH_ALG_ARGON2ID13.value,
+            )
+            check(libSodiumResult == 0)
+        } finally {
+            Arrays.fill(passwordBytesArray, 0x00)
+        }
 
         return result
     }
@@ -46,7 +65,7 @@ class LibSodiumArgon2PwHash(
     }
 
     companion object {
-        private const val SALT_LEN = com.goterl.lazysodium.interfaces.PwHash.SALTBYTES
+        private const val SALT_LEN = LibSodiumPwHash.SALTBYTES
     }
 }
 

--- a/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/SlothParameterBenchmarkTest.kt
+++ b/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/SlothParameterBenchmarkTest.kt
@@ -54,7 +54,10 @@ class SlothParameterBenchmarkTest {
     private fun internal_whenBenchmark_thenResultingRuntimeIsSlightlyLarger(
         targetDuration: Duration,
     ) {
-        val instance = getInstance()
+        // We want to skip instead of using the mocked SE, as we need the real one for the
+        // verification of the runtime using the normal `SlothLib` API below.
+        val instance = getInstance(useMockedSecureElementOtherwise = false)
+
         val benchmarkResult = instance.determineParameter(targetDuration)
 
         assertThat(benchmarkResult.duration).isGreaterThanOrEqualTo(targetDuration)
@@ -69,7 +72,7 @@ class SlothParameterBenchmarkTest {
         )
 
         val waitingTime = measureWaitingTime {
-            longSloth.createNewKey(pw = "passphrase")
+            longSloth.createNewKey(pw = "passphrase".toCharArray())
         }
         assertThat(waitingTime).isGreaterThan(targetDuration)
         assertThat(waitingTime).isLessThan(targetDuration.multipliedBy(5))
@@ -119,8 +122,11 @@ class SlothParameterBenchmarkTest {
         return Duration.ofMillis(end - start)
     }
 
-    private fun getInstance(): SlothParameterBenchmark {
-        val secureElement = createSecureElementOrSkip(context = context)
+    private fun getInstance(useMockedSecureElementOtherwise: Boolean = true): SlothParameterBenchmark {
+        val secureElement = createSecureElementOrSkip(
+            context = context,
+            useMockedSecureElementOtherwise = useMockedSecureElementOtherwise,
+        )
         return SlothParameterBenchmark(secureElement)
     }
 }

--- a/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/crypto/Pbkdf2PwHashTest.kt
+++ b/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/crypto/Pbkdf2PwHashTest.kt
@@ -15,8 +15,8 @@ class Pbkdf2PwHashTest {
 
     @Test
     fun testHash_whenSameInput_thenSameOutput() {
-        val h1 = instance.deriveHash(salt, "test", 32)
-        val h2 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
+        val h2 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         assertThat(h1).isEqualTo(h2)
     }
@@ -24,7 +24,7 @@ class Pbkdf2PwHashTest {
     @Test
     fun testHash_whenInteractiveParameters_thenSucceeds() {
         val instance = Pbkdf2PwHash(Pbkdf2PwHashParams.INTERACTIVE)
-        val h1 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         assertThat(h1).isNotEmpty()
     }
@@ -32,7 +32,7 @@ class Pbkdf2PwHashTest {
     @Test
     fun testHash_whenOwaspParameters_thenSucceeds() {
         val instance = Pbkdf2PwHash(Pbkdf2PwHashParams.OWASP)
-        val h1 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         assertThat(h1).isNotEmpty()
     }
@@ -40,7 +40,7 @@ class Pbkdf2PwHashTest {
     @Test
     fun testHash_whenOwaspSha256Parameters_thenSucceeds() {
         val instance = Pbkdf2PwHash(Pbkdf2PwHashParams.OWASP_SHA256)
-        val h1 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         assertThat(h1).isNotEmpty()
     }
@@ -48,25 +48,25 @@ class Pbkdf2PwHashTest {
     @Test
     fun testHash_whenLongKeyLength_thenSucceeds() {
         val len = 10 * 1024 * 1024 // 10 MiB
-        val h = instance.deriveHash(salt, "test", len)
+        val h = instance.deriveHash(salt, "test".toCharArray(), len)
 
         assertThat(h).hasSize(len)
     }
 
     @Test
     fun testHash_whenDifferentSalt_thenDifferentOutput() {
-        val h1 = instance.deriveHash(salt, "test", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
 
         val differentSalt = instance.createSalt()
-        val h2 = instance.deriveHash(differentSalt, "test", 32)
+        val h2 = instance.deriveHash(differentSalt, "test".toCharArray(), 32)
 
         assertThat(h1).isNotEqualTo(h2)
     }
 
     @Test
     fun testHash_whenDifferentPassword_thenDifferentOutput() {
-        val h1 = instance.deriveHash(salt, "test", 32)
-        val h2 = instance.deriveHash(salt, "different", 32)
+        val h1 = instance.deriveHash(salt, "test".toCharArray(), 32)
+        val h2 = instance.deriveHash(salt, "different".toCharArray(), 32)
 
         assertThat(h1).isNotEqualTo(h2)
     }

--- a/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/impl/HiddenSlothImplTest.kt
+++ b/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/impl/HiddenSlothImplTest.kt
@@ -18,7 +18,7 @@ import java.io.File
 import javax.crypto.AEADBadTagException
 
 private val DEFAULT_HANDLE = "handle".encodeToByteArray()
-private const val DEFAULT_PASSWORD = "password"
+private val DEFAULT_PASSWORD = "password".toCharArray()
 
 @RunWith(AndroidJUnit4::class)
 class HiddenSlothImplTest {
@@ -121,7 +121,7 @@ class HiddenSlothImplTest {
 
         instance.init(storage, DEFAULT_HANDLE)
         instance.encrypt(storage, DEFAULT_PASSWORD, data)
-        instance.decrypt(storage, "wrong passphrase")
+        instance.decrypt(storage, "wrong passphrase".toCharArray())
     }
 
     @Test(expected = AEADBadTagException::class)

--- a/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/impl/LongSlothImplTest.kt
+++ b/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/impl/LongSlothImplTest.kt
@@ -6,6 +6,7 @@ import com.lambdapioneer.sloth.crypto.Pbkdf2PwHash
 import com.lambdapioneer.sloth.storage.OnDiskStorage
 import com.lambdapioneer.sloth.testing.createSecureElementOrSkip
 import com.lambdapioneer.sloth.utils.secureRandomBytes
+import com.lambdapioneer.sloth.utils.secureRandomChars
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -13,7 +14,7 @@ import org.junit.runner.RunWith
 import java.io.File
 
 private val DEFAULT_HANDLE = "handle".encodeToByteArray()
-private const val DEFAULT_PASSWORD = "password"
+private val DEFAULT_PASSWORD = "password".toCharArray()
 private const val DEFAULT_OUTPUT_LENGTH = 32
 
 @RunWith(AndroidJUnit4::class)
@@ -51,7 +52,7 @@ class LongSlothImplTest {
     @Test
     fun whenKeyGenWithLongPassword_thenYieldSameKey() {
         val instance = createInstance()
-        val pw = secureRandomBytes(255).decodeToString()
+        val pw = secureRandomChars(255)
 
         val k1 = instance.keyGen(
             storage = storage,
@@ -82,7 +83,7 @@ class LongSlothImplTest {
 
         val k2 = instance.derive(
             storage = storage,
-            pw = "not the default password",
+            pw = "not the default password".toCharArray(),
             outputLengthBytes = DEFAULT_OUTPUT_LENGTH
         )
 

--- a/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/utils/ByteArrayExtensionsTest.kt
+++ b/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/utils/ByteArrayExtensionsTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class UtilsTest {
+class ByteArrayExtensionsTest {
 
     @Test
     fun testHexEncodeDecode_whenEmpty_thenEmpty() {

--- a/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/utils/SecureRandomExtensionsTests.kt
+++ b/android/sloth/src/androidTest/java/com/lambdapioneer/sloth/utils/SecureRandomExtensionsTests.kt
@@ -1,0 +1,111 @@
+package com.lambdapioneer.sloth.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.nio.CharBuffer
+import java.security.SecureRandom
+import kotlin.random.Random
+import kotlin.random.nextInt
+
+@RunWith(AndroidJUnit4::class)
+class SecureRandomExtensionsTests {
+
+    @Test
+    fun testSecureRandomBytes_whenCalledMultipleTimes_thenDifferentResults() {
+        val arr1 = secureRandomBytes(length = 32)
+        val arr2 = secureRandomBytes(length = 32)
+        assertThat(arr1).isNotEqualTo(arr2)
+    }
+
+    @Test
+    fun testSecureRandomChars_whenCalledMultipleTimes_thenDifferentResults() {
+        val arr1 = secureRandomChars(length = 32)
+        val arr2 = secureRandomChars(length = 32)
+        assertThat(arr1).isNotEqualTo(arr2)
+    }
+
+    @Test
+    fun testSecureRandomChars_whenCalledWithEntropy_thenResultingLengthsPlausible() {
+        // for a value lower than the per-character entropy, the resulting array should one
+        // character long
+        val entropyLow = 10.0
+        val arrLow = secureRandomChars(entropy = entropyLow)
+        assertThat(arrLow).hasSize(1)
+
+        // for a value just above the per-character entropy, the resulting array should be two
+        // characters long
+        val entropyTwo = 16.0
+        val arrTwo = secureRandomChars(entropy = entropyTwo)
+        assertThat(arrTwo).hasSize(2)
+
+        // for a practical (high) value, the length should match our expectations and be rounded up
+        val entropyHigh = 128.0
+        val arrHigh = secureRandomChars(entropy = entropyHigh)
+        assertThat(arrHigh).hasSize(128 / 16 + 1)
+    }
+
+    @Test
+    fun testSecureRandomChars_whenGeneratingMany_thenAllAreValidStrings() {
+        val n = 10_000
+        val r = Random(0)
+        repeat(n) {
+            val length = r.nextInt(1..64)
+            val arr = secureRandomChars(length = length)
+
+            // ensure that encoding directly works
+            val encodedByteBufferDirectly = Charsets.UTF_8.encode(CharBuffer.wrap(arr))
+            val encodedByteArrayDirectly = encodedByteBufferDirectly.array().copyOfRange(
+                fromIndex = 0,
+                toIndex = encodedByteBufferDirectly.limit()
+            )
+            assertThat(encodedByteArrayDirectly).isNotEmpty()
+            assertThat(encodedByteArrayDirectly.size).isGreaterThanOrEqualTo(length)
+
+            // ensure that encoding via String works
+            val encodedByteArrayViaString = String(arr).encodeToByteArray()
+            assertThat(encodedByteArrayViaString).isNotEmpty()
+            assertThat(encodedByteArrayViaString.size).isGreaterThanOrEqualTo(length)
+
+            // also, both should be equal
+            assertThat(encodedByteArrayDirectly).isEqualTo(encodedByteArrayViaString)
+        }
+    }
+
+    @Test
+    @Suppress("DEPRECATION") // for `Char.toInt()`
+    fun testSecureRandomNextChar_whenGeneratingMany_thenPlausiblyDistributedAmongValidChars() {
+        val validRangePreSurrogates = 0x0000 until 0xD800 // start inclusive, end exclusive
+        val invalidRangeSurrogates = 0xD800..0xDFFF // start inclusive, end inclusive
+        val validRangePostSurrogates = 0xE000..0xFFFF // start inclusive, end inclusive
+
+        // ensure that our ranges have same cardinality as all possible `Char` values
+        val numValidCharValues = validRangePreSurrogates.count() + validRangePostSurrogates.count()
+        val numTotalCharValues = numValidCharValues + invalidRangeSurrogates.count()
+        assertThat(numTotalCharValues).isEqualTo(Char.MAX_VALUE.toInt() + 1) // fence post
+
+        // generate an average of 10 hits per valid characters
+        val target = 10.0
+        val n = (numValidCharValues * target).toInt()
+        val counts = IntArray(size = numTotalCharValues)
+        val sr = SecureRandom()
+        repeat(n) {
+            val c = sr.nextChar()
+            counts[c.toInt()]++
+        }
+
+        fun getAverageHitsForRange(range: IntRange): Double {
+            var sum = 0.0
+            range.forEach { sum += counts[it] }
+            return sum / range.count()
+        }
+
+        // we expect an average of 10 hits in the valid ranges, and none in the "invalid" range
+        val offset = Offset.offset(0.1)
+        assertThat(getAverageHitsForRange(validRangePreSurrogates)).isCloseTo(target, offset)
+        assertThat(getAverageHitsForRange(invalidRangeSurrogates)).isEqualTo(0.0)
+        assertThat(getAverageHitsForRange(validRangePostSurrogates)).isCloseTo(target, offset)
+    }
+}

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/HiddenSloth.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/HiddenSloth.kt
@@ -75,7 +75,7 @@ class HiddenSloth internal constructor(
      * [identifier]. The storage must have been previous initialized using [onAppStart].
      */
     fun encryptToStorage(
-        pw: String,
+        pw: CharArray,
         data: ByteArray,
     ) {
         check(isInitialized)
@@ -85,6 +85,15 @@ class HiddenSloth internal constructor(
     }
 
     /**
+     * Encrypts the given [data] under the provided [pw] using the [storage] namespaced to
+     * [identifier]. The storage must have been previous initialized using [onAppStart].
+     */
+    fun encryptToStorage(
+        pw: String,
+        data: ByteArray,
+    ) = encryptToStorage(pw = pw.toCharArray(), data = data)
+
+    /**
      * Authenticates and decrypts the entire storage using the provided password. If the password
      * does not unlock the storage, a [SlothDecryptionFailed] exception is thrown.
      *
@@ -92,7 +101,7 @@ class HiddenSloth internal constructor(
      * (b) the password is wrong, or (c) the storage has been tampered with.
      */
     fun decryptFromStorage(
-        pw: String,
+        pw: CharArray,
     ): ByteArray {
         check(isInitialized)
         val namespacedStorage = storage.getOrCreateNamespace(identifier)
@@ -108,11 +117,22 @@ class HiddenSloth internal constructor(
     }
 
     /**
+     * Authenticates and decrypts the entire storage using the provided password. If the password
+     * does not unlock the storage, a [SlothDecryptionFailed] exception is thrown.
+     *
+     * Note that failure to decrypt can mean that (a) no data was ever encrypted,
+     * (b) the password is wrong, or (c) the storage has been tampered with.
+     */
+    fun decryptFromStorage(
+        pw: String,
+    ): ByteArray = decryptFromStorage(pw = pw.toCharArray())
+
+    /**
      * Computes the cached secrets for the given password. This can be used to speed up repeated
      * calls to [encryptToStorageWithCachedSecrets] and [decryptFromStorageWithCachedSecrets].
      */
     fun computeCachedSecrets(
-        pw: String,
+        pw: CharArray,
         authenticateStorage: Boolean = true,
     ): HiddenSlothCachedSecrets {
         check(isInitialized)
@@ -130,6 +150,18 @@ class HiddenSloth internal constructor(
             )
         }
     }
+
+    /**
+     * Computes the cached secrets for the given password. This can be used to speed up repeated
+     * calls to [encryptToStorageWithCachedSecrets] and [decryptFromStorageWithCachedSecrets].
+     */
+    fun computeCachedSecrets(
+        pw: String,
+        authenticateStorage: Boolean = true,
+    ): HiddenSlothCachedSecrets = computeCachedSecrets(
+        pw = pw.toCharArray(),
+        authenticateStorage = authenticateStorage
+    )
 
     /**
      * Uses the [HiddenSlothCachedSecrets] received from [computeCachedSecrets] to encrypt the

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/LongSloth.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/LongSloth.kt
@@ -27,7 +27,7 @@ class LongSloth internal constructor(
         val namespacedHandle = identifierToHandle(identifier)
         val namespacedStorage = storage.getOrCreateNamespace(identifier)
 
-        impl.onAppStart(storage = namespacedStorage, h=namespacedHandle)
+        impl.onAppStart(storage = namespacedStorage, h = namespacedHandle)
     }
 
     /**
@@ -37,7 +37,7 @@ class LongSloth internal constructor(
      * @param outputLengthBytes The length of the output key in bytes. Defaults to 32 bytes.
      */
     fun createNewKey(
-        pw: String,
+        pw: CharArray,
         outputLengthBytes: Int = 32,
     ): ByteArray {
         val namespacedHandle = identifierToHandle(identifier)
@@ -52,13 +52,27 @@ class LongSloth internal constructor(
     }
 
     /**
+     * Creates a new key with the given identifier and password.
+     *
+     * @param pw The password to use for the key derivation.
+     * @param outputLengthBytes The length of the output key in bytes. Defaults to 32 bytes.
+     */
+    fun createNewKey(
+        pw: String,
+        outputLengthBytes: Int = 32,
+    ): ByteArray = createNewKey(
+        pw = pw.toCharArray(),
+        outputLengthBytes = outputLengthBytes,
+    )
+
+    /**
      * Derives the secret for the given key identifier and password.
      *
      * @param pw The password to use for the key derivation.
      * @param outputLengthBytes The length of the output key in bytes. Defaults to 32 bytes.
      */
     fun deriveForExistingKey(
-        pw: String,
+        pw: CharArray,
         outputLengthBytes: Int = 32,
     ): ByteArray {
         val namespacedStorage = storage.getOrCreateNamespace(identifier)
@@ -69,6 +83,20 @@ class LongSloth internal constructor(
             outputLengthBytes = outputLengthBytes,
         )
     }
+
+    /**
+     * Derives the secret for the given key identifier and password.
+     *
+     * @param pw The password to use for the key derivation.
+     * @param outputLengthBytes The length of the output key in bytes. Defaults to 32 bytes.
+     */
+    fun deriveForExistingKey(
+        pw: String,
+        outputLengthBytes: Int = 32,
+    ): ByteArray = deriveForExistingKey(
+        pw = pw.toCharArray(),
+        outputLengthBytes = outputLengthBytes,
+    )
 
     /**
      * Checks the key with [identifier] exists.

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/crypto/Pbkdf2PwHash.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/crypto/Pbkdf2PwHash.kt
@@ -15,12 +15,12 @@ class Pbkdf2PwHash(
 
     override fun deriveHash(
         salt: ByteArray,
-        password: String,
+        password: CharArray,
         outputLengthInBytes: Int,
     ): ByteArray {
         val factory = SecretKeyFactory.getInstance(params.algorithm)
         val keySpec = PBEKeySpec(
-            /* password = */ password.toCharArray(),
+            /* password = */ password,
             /* salt = */ salt,
             /* iterationCount = */ params.iterationCount,
             /* keyLength = */ 8 * outputLengthInBytes

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/crypto/PwHash.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/crypto/PwHash.kt
@@ -20,5 +20,5 @@ interface PwHash {
      * @param password The password to use for the hash function.
      * @param outputLengthInBytes The length of the output hash in bytes.
      */
-    fun deriveHash(salt: ByteArray, password: String, outputLengthInBytes: Int): ByteArray
+    fun deriveHash(salt: ByteArray, password: CharArray, outputLengthInBytes: Int): ByteArray
 }

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/impl/HiddenSlothParams.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/impl/HiddenSlothParams.kt
@@ -6,9 +6,4 @@ package com.lambdapioneer.sloth.impl
 data class HiddenSlothParams(
     internal val payloadMaxLength: Int,
     internal val longSlothParams: LongSlothParams = LongSlothParams(),
-    internal val lambda: Int = SECURITY_PARAMETER_LAMBDA_DEFAULT,
-) {
-    companion object {
-        const val SECURITY_PARAMETER_LAMBDA_DEFAULT = 128
-    }
-}
+)

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/impl/LongSlothImpl.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/impl/LongSlothImpl.kt
@@ -15,6 +15,7 @@ import com.lambdapioneer.sloth.storage.WriteableStorage
 import com.lambdapioneer.sloth.utils.NoopTracer
 import com.lambdapioneer.sloth.utils.Tracer
 import com.lambdapioneer.sloth.utils.secureRandomBytes
+import com.lambdapioneer.sloth.utils.secureRandomChars
 
 /**
  * Keys for the values persisted in storage.
@@ -48,7 +49,7 @@ class LongSlothImpl(
             storage.updateAllLastModifiedTimestamps()
         } else {
             // if the storage does not exist, we create a new key under a randomly chosen passphrase
-            val randomPassphrase = secureRandomBytes(32).decodeToString()
+            val randomPassphrase = secureRandomChars(entropy = params.lambda.toDouble())
             keyGen(
                 storage = storage,
                 pw = randomPassphrase,
@@ -60,7 +61,7 @@ class LongSlothImpl(
 
     fun keyGen(
         storage: WriteableStorage,
-        pw: String,
+        pw: CharArray,
         h: ByteArray,
         outputLengthBytes: Int,
     ): ByteArray {
@@ -72,7 +73,7 @@ class LongSlothImpl(
         return derive(storage, pw, outputLengthBytes)
     }
 
-    fun derive(storage: ReadableStorage, pw: String, outputLengthBytes: Int): ByteArray {
+    fun derive(storage: ReadableStorage, pw: CharArray, outputLengthBytes: Int): ByteArray {
         tracer.addKeyValue("l", params.l.toString())
         tracer.addKeyValue("argon", pwHash.toString())
 

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/impl/LongSlothParams.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/impl/LongSlothParams.kt
@@ -3,14 +3,21 @@ package com.lambdapioneer.sloth.impl
 import com.lambdapioneer.sloth.utils.ceilToNextKiB
 
 /**
- * The LongSloth parameters as defined in the paper. The L parameter is rounded up to the next KiB.
+ * The LongSloth parameters as defined in the paper.
  *
- * See [SlothLib.determineParameter] as a practical way to determine a suitable L parameter.
+ * The [l] parameter is rounded up to the next KiB. See [SlothLib.determineParameter] as a practical
+ * way to determine a suitable L parameter.
+ *
+ * The [lambda] parameter is the overall security parameter and usually set to 128.
  */
-class LongSlothParams(l: Int = SECURITY_PARAMETER_L_DEFAULT) {
-    val l = ceilToNextKiB(l)
+class LongSlothParams(
+    l: Int = SECURITY_PARAMETER_L_DEFAULT,
+    internal val lambda: Int = SECURITY_PARAMETER_LAMBDA_DEFAULT
+) {
+    internal val l = ceilToNextKiB(l)
 
     companion object {
         const val SECURITY_PARAMETER_L_DEFAULT = 100 * 1024
+        const val SECURITY_PARAMETER_LAMBDA_DEFAULT = 128
     }
 }

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/utils/ByteArrayExtensions.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/utils/ByteArrayExtensions.kt
@@ -1,65 +1,7 @@
 package com.lambdapioneer.sloth.utils
 
 import java.nio.ByteBuffer
-import java.security.SecureRandom
-import kotlin.math.ceil
-import kotlin.math.log2
-import kotlin.math.roundToInt
 
-/**
- * Creates a new byte array of random bytes sourced from [SecureRandom].
- */
-fun secureRandomBytes(length: Int): ByteArray {
-    require(length >= 0)
-    val secureRandom = SecureRandom()
-
-    val result = ByteArray(length)
-    secureRandom.nextBytes(result)
-    return result
-}
-
-/**
- * Creates a new array of random Char elements sourced from [SecureRandom.nextChar] of the
- * given [length].
- */
-fun secureRandomChars(length: Int): CharArray {
-    require(length >= 0)
-    val secureRandom = SecureRandom()
-
-    return CharArray(length) { secureRandom.nextChar() }
-}
-
-/**
- * Creates a new array of random Char elements sourced from [SecureRandom.nextChar] of a given
- * total entropy assuming 15.954 bits per character.
- */
-fun secureRandomChars(entropy: Double): CharArray {
-    require(entropy > 0)
-
-    val bitsPerChar = 15.594 // log2(2^16 - 2048) = 15.954 + eps
-    val length = ceil(entropy / bitsPerChar).toInt()
-
-    return secureRandomChars(length = length)
-}
-
-/**
- * Returns a [Char] element chosen uniformly at random from all single code units excluding the
- * surrogate range (0xD800..0xDFFF). This ensures that an array of results from this function
- * always represents a valid string.
- *
- * Since we exclude a range of 2048 (0x800) characters, the total entropy per character is just
- * log2(2^16 - 2^11) ~= 15.954...
- */
-fun SecureRandom.nextChar(): Char {
-    val surrogateRangeSize = Char.MAX_SURROGATE.toInt() - Char.MIN_SURROGATE.toInt() + 1
-    val i = nextInt(Char.MAX_VALUE.toInt() - surrogateRangeSize)
-
-    return if (i >= Char.MIN_SURROGATE.toInt()) {
-        (i + surrogateRangeSize).toChar()
-    } else {
-        i.toChar()
-    }
-}
 
 /**
  * Decodes the given hex string as a byte array.

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/utils/ByteArrayExtensions.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/utils/ByteArrayExtensions.kt
@@ -2,6 +2,9 @@ package com.lambdapioneer.sloth.utils
 
 import java.nio.ByteBuffer
 import java.security.SecureRandom
+import kotlin.math.ceil
+import kotlin.math.log2
+import kotlin.math.roundToInt
 
 /**
  * Creates a new byte array of random bytes sourced from [SecureRandom].
@@ -13,6 +16,49 @@ fun secureRandomBytes(length: Int): ByteArray {
     val result = ByteArray(length)
     secureRandom.nextBytes(result)
     return result
+}
+
+/**
+ * Creates a new array of random Char elements sourced from [SecureRandom.nextChar] of the
+ * given [length].
+ */
+fun secureRandomChars(length: Int): CharArray {
+    require(length >= 0)
+    val secureRandom = SecureRandom()
+
+    return CharArray(length) { secureRandom.nextChar() }
+}
+
+/**
+ * Creates a new array of random Char elements sourced from [SecureRandom.nextChar] of a given
+ * total entropy assuming 15.954 bits per character.
+ */
+fun secureRandomChars(entropy: Double): CharArray {
+    require(entropy > 0)
+
+    val bitsPerChar = 15.594 // log2(2^16 - 2048) = 15.954 + eps
+    val length = ceil(entropy / bitsPerChar).toInt()
+
+    return secureRandomChars(length = length)
+}
+
+/**
+ * Returns a [Char] element chosen uniformly at random from all single code units excluding the
+ * surrogate range (0xD800..0xDFFF). This ensures that an array of results from this function
+ * always represents a valid string.
+ *
+ * Since we exclude a range of 2048 (0x800) characters, the total entropy per character is just
+ * log2(2^16 - 2^11) ~= 15.954...
+ */
+fun SecureRandom.nextChar(): Char {
+    val surrogateRangeSize = Char.MAX_SURROGATE.toInt() - Char.MIN_SURROGATE.toInt() + 1
+    val i = nextInt(Char.MAX_VALUE.toInt() - surrogateRangeSize)
+
+    return if (i >= Char.MIN_SURROGATE.toInt()) {
+        (i + surrogateRangeSize).toChar()
+    } else {
+        i.toChar()
+    }
 }
 
 /**

--- a/android/sloth/src/main/java/com/lambdapioneer/sloth/utils/SecureRandomExtensions.kt
+++ b/android/sloth/src/main/java/com/lambdapioneer/sloth/utils/SecureRandomExtensions.kt
@@ -1,0 +1,61 @@
+package com.lambdapioneer.sloth.utils
+
+import java.security.SecureRandom
+import kotlin.math.ceil
+
+
+/**
+ * Creates a new byte array of random bytes sourced from [SecureRandom].
+ */
+fun secureRandomBytes(length: Int): ByteArray {
+    require(length >= 0)
+    val secureRandom = SecureRandom()
+
+    val result = ByteArray(length)
+    secureRandom.nextBytes(result)
+    return result
+}
+
+/**
+ * Creates a new array of random Char elements sourced from [SecureRandom.nextChar] of the
+ * given [length].
+ */
+fun secureRandomChars(length: Int): CharArray {
+    require(length >= 0)
+    val secureRandom = SecureRandom()
+
+    return CharArray(length) { secureRandom.nextChar() }
+}
+
+/**
+ * Creates a new array of random Char elements sourced from [SecureRandom.nextChar] of a given
+ * total entropy assuming 15.954 bits per character.
+ */
+fun secureRandomChars(entropy: Double): CharArray {
+    require(entropy > 0)
+
+    val bitsPerChar = 15.594 // log2(2^16 - 2048) = 15.954 + eps
+    val length = ceil(entropy / bitsPerChar).toInt()
+
+    return secureRandomChars(length = length)
+}
+
+/**
+ * Returns a [Char] element chosen uniformly at random from all single code units excluding the
+ * surrogate range (0xD800..0xDFFF). This ensures that an array of results from this function
+ * always represents a valid string.
+ *
+ * Since we exclude a range of 2048 (0x800) characters, the total entropy per character is just
+ * log2(2^16 - 2^11) ~= 15.954...
+ */
+@Suppress("DEPRECATION") // for `Char.toInt()`
+fun SecureRandom.nextChar(): Char {
+    val surrogateRangeSize = Char.MAX_SURROGATE.toInt() - Char.MIN_SURROGATE.toInt() + 1
+    val i = nextInt(Char.MAX_VALUE.toInt() - surrogateRangeSize)
+
+    return if (i >= Char.MIN_SURROGATE.toInt()) {
+        (i + surrogateRangeSize).toChar()
+    } else {
+        i.toChar()
+    }
+}


### PR DESCRIPTION
**Summary**

It is general best practise to minimize the exposure of secrets in memory.  As such, `Strings` are not great, as they are immutable and we have to hope for the GC to collect them eventually. On the other hand, `CharArrays` allow us (even if not guaranteed by the spec) to overwrite their content after usage.

This PR changes the API to allow for passing in the user password as a `CharArray` instead of `String`s. If your code currently uses `String`, you can simply call `toCharArray` which will result in identical behaviour.

Whether this makes a difference in practise, e.g. against a root-level adversary that can already read memory, is a valid discussion to have. However, there exist at least some people who believe that this is a worthwhile defence-in-depth.

**Testplan**

Run all tests on a physical device (Pixel 6a) and added a test that ensures we maintain backwards-compatibility.